### PR TITLE
Java 9 compatibility

### DIFF
--- a/src/main-rxtx/java/gnu/io/RXTXCommDriver.java
+++ b/src/main-rxtx/java/gnu/io/RXTXCommDriver.java
@@ -340,7 +340,7 @@ public class RXTXCommDriver implements CommDriver {
         String val = null;
         Properties origp = System.getProperties(); // save system properties
 
-        String[] ext_dirs = System.getProperty("java.ext.dirs").split(":");
+        String[] ext_dirs = System.getProperty("java.ext.dirs", System.getProperty("user.home")).split(":");
         String fs = System.getProperty("file.separator");
         for (int n = 0; n < ext_dirs.length; ++n) {
             String ext_file = "?";


### PR DESCRIPTION
Java 9 has removed the java extension dirs as well as the System Property "java.ext.dirs". This causes a NPE in RXTXCommDriver. Therefore no serial connection is possible using Java 9.
This minor change introduces a fallback to read the properties from "user.home" if "java.ext.dirs" does not exist.