### PR TITLE
Add note about macOS

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -116,7 +116,7 @@ Afterwards you have to log out and log back in in order for the group
 changes to become active.
         
 
-=== Windows
+=== Windows and macOS
 
 On Windows you need to copy the native library of RXTX for your
 specific system to the folder that is in the java.libary.path. To


### PR DESCRIPTION
The chapter about the native lib applies to Windows just as well as for macOS.  The linked ZIP file contains a Mac binary in the `mac-10.5` folder. However, it works in newer macOS versions, too (tested with 12.6).